### PR TITLE
fix(mask): allow re-masking a masked value

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,7 +24,7 @@ export function format (
 }
 
 export function mask (value: string, placeholder = '*'): string {
-  return clean(value)
+  return clean(value, placeholder)
     .split('')
     .map((c, i, s) => {
       return i < 5 ? (i === s.length - 1 ? c : placeholder) : c

--- a/test.ts
+++ b/test.ts
@@ -90,3 +90,9 @@ test(`validate`, async t => {
   t.is(ssn.validate('123-12-12345'), false)
   t.is(ssn.validate('12-312-1234'), false)
 })
+
+test(`masking a masked value`, t => {
+  const masked = '*****3123'
+  const remasked = ssn.mask(masked, '*')
+  t.is(remasked, masked)
+})


### PR DESCRIPTION
Masking an already masked value should result in the same output.